### PR TITLE
Upgrade critical to ^1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build": "rimraf ./dist && webpack --config ./webpack.config.js"
   },
   "dependencies": {
-    "critical": "^0.9.0"
+    "critical": "^1.0.0"
   },
   "files": [
     "README.md",


### PR DESCRIPTION
Critical 1.0.0 supports headless chrome now: https://github.com/addyosmani/critical/blob/master/CHANGELOG.md#v100--2017-11-06