### PR TITLE
Chore/issue 14 add ci build and documentation for critical

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: thegreenhouse/nodejs-dev:0.2.0
+      - image: circleci/node:8.9.4
 
     working_directory: ~/repo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:8.9.4
+      - image: thegreenhouse/nodejs-dev:0.2.0
 
     working_directory: ~/repo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,29 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/node:8.9.4
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "package.json" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run:
+          name: Install Project Dependencies
+          command: npm install
+
+      - run:
+          name: Run Tests
+          command: npm test
+
+      - run:
+          name: Run CI Build
+          command: npm run ci

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 .idea/
 npm-debug.log
 test/**/build/
+build/

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A fork of Critical Webpack Plugin.
 
 This is simplified and runs after all files have been emitted so you can use it after Extract Text and HTML Webpack Plugin.
 
+**Note**: [**critical** itself has a dependency on puppeteer](https://github.com/addyosmani/critical/releases/tag/v1.0.0) to run headless Chrome, so make sure your build environment (local, CI, etc) where your running webpack has the necessary operating system packages installed.  See this page for more information on [troubleshooting](https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md) puppeteer.
+
 ### Install
 
 ```

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "homepage": "https://github.com/anthonygore/html-critical-webpack-plugin#readme",
   "scripts": {
     "build": "rimraf ./dist && webpack --config ./webpack.config.js",
+    "ci": "webpack --config ./webpack.config.ci.js",
     "test": "mocha ./test/**/*.spec.js"
   },
   "dependencies": {

--- a/test/cases/generate-critical-css/generate-critical-css.spec.js
+++ b/test/cases/generate-critical-css/generate-critical-css.spec.js
@@ -31,7 +31,7 @@ describe('HtmlCriticalWebpackPlugin Cases: Generate Critical CSS', () => {
         const indexHtmlDom = new JSDOM(indexHtmlString);
         const linkTags = indexHtmlDom.window.document.querySelectorAll('link');
         
-        assert.equal(linkTags.length, 1);
+        assert.equal(linkTags.length, 2);
         assert.equal(linkTags[0].getAttribute('rel'), 'preload');
         assert.equal(linkTags[0].getAttribute('as'), 'style');
 
@@ -45,7 +45,7 @@ describe('HtmlCriticalWebpackPlugin Cases: Generate Critical CSS', () => {
         const indexHtmlDom = new JSDOM(indexHtmlString);
         const noscriptTags = indexHtmlDom.window.document.querySelectorAll('noscript');
         
-        assert.equal(noscriptTags.length, 1);
+        assert.equal(noscriptTags.length, 2);
 
         done();
       });

--- a/test/cases/generate-critical-css/index.css
+++ b/test/cases/generate-critical-css/index.css
@@ -11,5 +11,5 @@
   
 .fade-appear.fade-appear-active {
   opacity: 1;
-  transition: opacity 600ms ease-in; //ms should match the value of transitionAppearTimeout
+  transition: opacity 600ms ease-in; /* ms should match the value of transitionAppearTimeout */
 }

--- a/test/cases/generate-critical-css/main.css
+++ b/test/cases/generate-critical-css/main.css
@@ -19,7 +19,7 @@
   text-align: center;
   font-weight: 100;
   font-size: 1.4rem;
-  color: $gold;
+  color: yellow;
   width: 100%;
   padding: .55rem;
   white-space: nowrap;
@@ -50,7 +50,7 @@
 }
 
 .card-block a {
-  color: $black;
+  color: #020202;
 }
 
 .card-info {

--- a/webpack.config.ci.js
+++ b/webpack.config.ci.js
@@ -1,0 +1,41 @@
+const ExtractTextWebpackPlugin = require('extract-text-webpack-plugin');
+const HtmlWebpackCriticalPlugin = require('./index');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const webpack = require('webpack');
+const path = require('path');
+
+const OUTPUT_DIR = path.resolve(__dirname, 'build');
+
+module.exports = {
+  
+  entry: {
+    index: './test/cases/generate-critical-css/index.js'
+  },
+
+  output: {
+    path: OUTPUT_DIR,
+    filename: 'html-crtitical-webpack-plugin.js'
+  },
+
+  module: {
+    rules: [{
+      test: /\.css$/,
+      use: ExtractTextWebpackPlugin.extract({
+        use: ['css-loader']
+      })
+    }]
+  },
+
+  plugins: [
+    new HtmlWebpackPlugin(),
+
+    new ExtractTextWebpackPlugin('styles.[chunkhash].css'),
+    
+    new HtmlWebpackCriticalPlugin({
+      base: OUTPUT_DIR,
+      src: 'index.html',
+      dest: 'index.html',
+      inline: true
+    })
+  ]
+};


### PR DESCRIPTION
resolves #14 

### Overview
This PR aims to document this project's dependency on [**critical**](https://www.npmjs.com/package/critical) which was [updated recently](https://github.com/addyosmani/critical/releases/tag/v1.0.0) to use [Headless Chrome](https://developers.google.com/web/updates/2017/04/headless-chrome) (via [**puppeteer**](https://github.com/GoogleChrome/puppeteer)) (instead of PhantomJS).  

This now requires consuming build time environments have support to run [Headless Chrome](https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md).

### Changes
1. Added a CircleCi config file (using an image that supports Headless Chrome)
1. Added consumer documentation around Headless Chrome / puppeteer
1. Fixed some tests

_**Notes:**_
Ran the build once using a "stock" Docker image, [**circleci/node:8.9.4**]() to demonstrate the issue of the build needed Headless Chrome packages.
> // TODO add results here

Then updated the PR to use a [Docker image](https://hub.docker.com/r/thegreenhouse/nodejs-dev/) I put together specifically with the goal of being able to [run Headless Chrome for NodeJS projects](https://github.com/thegreenhouseio/docker-nodejs-dev/blob/master/Dockerfile).
> // TODO add results here

### TODO
1. [ ] Update this ticket with results, screenshots, links to the builds, etc
1. [ ] Should add developer documentation around using Docker